### PR TITLE
Add GPT-4o ticket summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,4 +70,4 @@ The required/working versions of these packages are listed in [requirements.txt]
 
 [discord.py](https://github.com/Rapptz/discord.py)
 
-[aiohttp](https://github.com/aio-libs/aiohttp)
+[openai](https://github.com/openai/openai-python) - used for GPT-4o ticket summaries and message translation

--- a/changelogs.txt
+++ b/changelogs.txt
@@ -1,0 +1,6 @@
+* Added GPT-4o ticket summary in closed ticket logs.
+* Translated incoming messages to English when relayed to moderators.
+* Reintroduced aiohttp for log searches using a dynamic import.
+* Added replyTranslate and areplyTranslate commands for sending translated replies.
+
+* Added OpenAI dependency for translation and AI summarization features.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 bleach==6.1.0
 discord.py==2.3.2
-# aiohttp is automatically installed by discord.py
+openai
+


### PR DESCRIPTION
## Summary
- automatically generate GPT-4o summaries when closing a ticket
- translate incoming messages to English before relaying them to mods
- add `replyTranslate` and `areplyTranslate` commands for translated replies
- reintroduce aiohttp via dynamic import for log searches
- document OpenAI dependency

## Testing
- `python -m py_compile modmail.py`


------
https://chatgpt.com/codex/tasks/task_e_686bd8939058832f85f003e150ac58b3