### PR TITLE
Add closet command for translated ticket closing

### DIFF
--- a/changelogs.txt
+++ b/changelogs.txt
@@ -5,4 +5,5 @@
 * Tokens and API keys now load from a .env file using python-dotenv.
 * Corrected OpenAI API calls using AsyncOpenAI client.
 * Initialized OpenAI client with httpx.AsyncClient to avoid proxy errors.
+* Added closet command for closing tickets with translated reasons.
 

--- a/modmail.py
+++ b/modmail.py
@@ -888,6 +888,18 @@ async def close(ctx, *, reason: str = ''):
             pass
 
 
+@bot.command()
+@commands.check(is_helper)
+async def closet(ctx, language: str, *, reason: str = ''):
+    """Closes a ticket and translates the reason for the user."""
+
+    # Translate the closing reason to the requested language
+    translated = await translate_to_language(reason, language)
+
+    # Reuse the existing close command with the translated reason
+    await ctx.invoke(close, reason=translated)
+
+
 @bot.group(invoke_without_command=True, aliases=['snippets'])
 @commands.check(is_helper)
 async def snippet(ctx, name: str):


### PR DESCRIPTION
## Summary
- add a new `closet` command to close tickets with a translated reason
- document new command in changelog

## Testing
- `python -m py_compile modmail.py`


------
https://chatgpt.com/codex/tasks/task_e_686bf8b28130832f9e57fafda77bd9ac