### PR TITLE
Track channel count in category name

### DIFF
--- a/changelogs.txt
+++ b/changelogs.txt
@@ -6,4 +6,5 @@
 * Corrected OpenAI API calls using AsyncOpenAI client.
 * Initialized OpenAI client with httpx.AsyncClient to avoid proxy errors.
 * Added closet command for closing tickets with translated reasons.
+* Category name now reflects the number of channels as [n/50] and updates on creation or deletion.
 


### PR DESCRIPTION
## Summary
- keep ticket category name updated with `[count/50]`
- show current channel count when bot starts
- update count when channels in the category are created or deleted

## Testing
- `python -m py_compile modmail.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cd5804154832fa87e05317f8ee20a