### PR TITLE
Add language detection step for translations

### DIFF
--- a/changelogs.txt
+++ b/changelogs.txt
@@ -7,4 +7,5 @@
 * Initialized OpenAI client with httpx.AsyncClient to avoid proxy errors.
 * Added closet command for closing tickets with translated reasons.
 * Category name now reflects the number of channels as [n/50] and updates on creation or deletion.
+* Added language detection before translation to avoid unnecessary English translations.
 


### PR DESCRIPTION
## Summary
- import googletrans and set up a translator helper
- detect the language of incoming user messages using GPT-4o
- only translate to English when the detected language is not English
- document new behaviour in the changelog

## Testing
- `python -m py_compile modmail.py`

------
https://chatgpt.com/codex/tasks/task_e_686cea9c4130832faea8fa798f33b40f