### PR TITLE
Add GPT-only translation path

### DIFF
--- a/changelogs.txt
+++ b/changelogs.txt
@@ -7,4 +7,6 @@
 * Initialized OpenAI client with httpx.AsyncClient to avoid proxy errors.
 * Added closet command for closing tickets with translated reasons.
 * Category name now reflects the number of channels as [n/50] and updates on creation or deletion.
+* Added language detection before translation to avoid unnecessary English translations.
+* Removed googletrans fallback to rely solely on OpenAI for translation.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 bleach==6.1.0
 discord.py==2.3.2
+# Core dependencies
 openai
 python-dotenv
-# Used for fallback translation when OpenAI fails
-googletrans==4.0.0rc1
 # aiohttp is automatically installed by discord.py
 


### PR DESCRIPTION
## Summary
- remove googletrans and related fallback logic
- rely solely on GPT-4o for language detection and translation
- document removal in changelog

## Testing
- `python -m py_compile modmail.py`


------
https://chatgpt.com/codex/tasks/task_e_686cea9c4130832faea8fa798f33b40f