### PR TITLE
Load secrets from modmail.env

### DIFF
--- a/changelogs.txt
+++ b/changelogs.txt
@@ -2,7 +2,7 @@
 * Translated incoming messages to English when relayed to moderators.
 * Added replyTranslate and areplyTranslate commands for sending translated replies.
 * Added OpenAI dependency for translation and AI summarization features.
-* Tokens and API keys now load from a .env file using python-dotenv.
+* Tokens and API keys now load from a modmail.env file using python-dotenv.
 * Corrected OpenAI API calls using AsyncOpenAI client.
 * Initialized OpenAI client with httpx.AsyncClient to avoid proxy errors.
 * Added closet command for closing tickets with translated reasons.

--- a/modmail.py
+++ b/modmail.py
@@ -23,8 +23,8 @@ from dotenv import load_dotenv
 import re
 from googletrans import Translator, LANGUAGES
 
-# Load variables from a .env file for token and API access
-load_dotenv()
+# Load variables from a modmail.env file so tokens and API keys can be configured externally
+load_dotenv('modmail.env')
 class YesNoButtons(discord.ui.View):
     def __init__(self, timeout: int):
         super().__init__(timeout=timeout)


### PR DESCRIPTION
## Summary
- load token and API keys from `modmail.env`
- document new environment file in changelogs

## Testing
- `python -m py_compile modmail.py`

------
https://chatgpt.com/codex/tasks/task_e_686d0468c66c832f83418f06c765084b