### PR TITLE
Remove unused google translate import

### DIFF
--- a/changelogs.txt
+++ b/changelogs.txt
@@ -10,3 +10,4 @@
 * Added language detection before translation to avoid unnecessary English translations.
 
 
+* Removed unused googletrans import.

--- a/modmail.py
+++ b/modmail.py
@@ -21,7 +21,6 @@ import openai
 import httpx
 from dotenv import load_dotenv
 import re
-from googletrans import Translator, LANGUAGES
 
 # Load variables from a modmail.env file so tokens and API keys can be configured externally
 load_dotenv('modmail.env')


### PR DESCRIPTION
## Summary
- remove leftover googletrans import
- document removal in changelog

## Testing
- `python3 -m py_compile modmail.py`


------
https://chatgpt.com/codex/tasks/task_e_686d074d8ab0832f902c80d7b1ce8116