### PR TITLE
Add manual translation button

### DIFF
--- a/changelogs.txt
+++ b/changelogs.txt
@@ -11,3 +11,5 @@
 
 
 * Removed unused googletrans import.
+* Replaced automatic message translation with a button that translates on demand.
+* Translate button view now has no timeout so it remains usable indefinitely.


### PR DESCRIPTION
## Summary
- add TranslateView for manual translation
- replace automatic user message translation with TranslateView button
- make TranslateView persistent with timeout=None
- document changes in changelog

## Testing
- `python -m py_compile modmail.py`


------
https://chatgpt.com/codex/tasks/task_e_686f7265210c832fa84b01303c7e52d9