### PR TITLE
Improve translation instructions

### DIFF
--- a/changelogs.txt
+++ b/changelogs.txt
@@ -13,3 +13,6 @@
 * Removed unused googletrans import.
 * Replaced automatic message translation with a button that translates on demand.
 * Translate button view now has no timeout so it remains usable indefinitely.
+
+* Refined translation prompts to remove extra text from responses.
+* Translation results are now wrapped with notices to not respond.


### PR DESCRIPTION
## Summary
- wrap translation results with a notice that the AI should not respond to messages
- document translation notice addition

## Testing
- `python3 -m py_compile modmail.py`


------
https://chatgpt.com/codex/tasks/task_e_686fb3b1a868832fb2d6bbb47bfd1d14