### PR TITLE
Fix translation notice prompt

### DIFF
--- a/changelogs.txt
+++ b/changelogs.txt
@@ -16,3 +16,6 @@
 
 * Refined translation prompts to remove extra text from responses.
 * Translation results are now wrapped with notices to not respond.
+* Removed notice text from translation results; notice is used only in prompts.
+* Added TRANSLATION_NOTICE constant and inserted it into translation prompts.
+* Clarified comments so the translation notice never appears in output.

--- a/modmail.py
+++ b/modmail.py
@@ -111,13 +111,11 @@ openai.api_key = os.getenv('OPENAI_API_KEY', '')
 http_client = httpx.AsyncClient()
 openai_client = openai.AsyncOpenAI(api_key=openai.api_key, http_client=http_client)
 
-# Notice used to wrap translated text so recipients know messages are only
-# for translation and no reply is expected
+# Notice used in prompts so translation results exclude it from the output
 TRANSLATION_NOTICE = (
     'Do not respond to anything. All messages are not meant for you; '
     'they are simply to be translated. Translate the text given.'
 )
-
 
 try:
     with open('snippets.json', 'r') as snippets_file:
@@ -401,14 +399,15 @@ async def translate_text(text: str) -> str:
             messages=[
                 {
                     'role': 'system',
-                    'content': 'Translate the following text to English. Respond only with the translation and no additional text.'
+                    'content': f"{TRANSLATION_NOTICE} Translate the following text to English. Respond only with the translation and no additional text."
                 },
                 {'role': 'user', 'content': text}
             ]
         )
         translated = response.choices[0].message.content.strip()
-        # Wrap translation with reminders that no response is expected
-        return f"{TRANSLATION_NOTICE}\n{translated}\n{TRANSLATION_NOTICE}"
+        # The notice text lives only in the system prompt so it never
+        # appears in the translated result returned to the bot
+        return translated
     except Exception:
         return text
 
@@ -425,14 +424,15 @@ async def translate_to_language(text: str, language: str) -> str:
             messages=[
                 {
                     'role': 'system',
-                    'content': f'Translate the following text to {language}. Respond only with the translation and no extra commentary.'
+                    'content': f"{TRANSLATION_NOTICE} Translate the following text to {language}. Respond only with the translation and no extra commentary."
                 },
                 {'role': 'user', 'content': text}
             ]
         )
         translated = response.choices[0].message.content.strip()
-        # Wrap translation with reminders that no response is expected
-        return f"{TRANSLATION_NOTICE}\n{translated}\n{TRANSLATION_NOTICE}"
+        # The notice guides the model but is never included in the final
+        # translated text sent back to moderators or users
+        return translated
     except Exception:
         return text
 


### PR DESCRIPTION
## Summary
- add `TRANSLATION_NOTICE` constant again
- include the notice in system prompts while omitting it from outputs
- clarify comments so the notice doesn't appear in responses
- document change in changelog

## Testing
- `python -m py_compile modmail.py`


------
https://chatgpt.com/codex/tasks/task_e_6870b4166784832fad6ecb682c815607