### PR TITLE
Add refresh command to update channel count

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ is given to the bot owner(s) in the Discord Developer Portal (although they will
 - `anonymous_tickets` (true/false) names ticket channels anonymously, rather than using the name of the user.
 - `send_with_command_only` (true/false) only allows messages to be sent using `!reply` and `!areply`
 
-The `!refresh` command will re-read the config file, so you can change these values without restarting the bot.
-It also resets a few things behind the scenes which may help fix some issues.
+The `!reloadconfig` command will re-read the config file so you can change these values without restarting the bot.
+Use `!refresh` to manually update the ticket category name if the channel count becomes incorrect.
 
 ### Dependancies
 

--- a/changelogs.txt
+++ b/changelogs.txt
@@ -21,3 +21,6 @@
 * Clarified comments so the translation notice never appears in output.
 * Expanded notice comment to emphasize it is excluded from translations.
 
+* Added refresh command to manually update the ticket category channel count.
+* Renamed the old refresh command to reloadconfig for reloading the config file.
+

--- a/modmail.py
+++ b/modmail.py
@@ -1208,7 +1208,16 @@ async def ping(ctx):
 @bot.command()
 @commands.check(is_helper)
 async def refresh(ctx):
-    """Re-reads the external config file"""
+    """Refresh the ticket category name with the current channel count"""
+
+    await update_category_name()
+    await ctx.message.add_reaction('\u2705')
+
+
+@bot.command(name='reloadconfig')
+@commands.check(is_helper)
+async def reload_config(ctx):
+    """Re-read the external config file"""
 
     with open('config.json', 'r') as file:
         config.update(json.load(file))


### PR DESCRIPTION
## Summary
- introduce `refresh` command to update the ticket category name
- rename previous `refresh` command to `reloadconfig`
- document new commands in README
- update changelog

## Testing
- `python3 -m py_compile modmail.py`

------
https://chatgpt.com/codex/tasks/task_e_6880d779547c832fa6eca45f7639a81e