### PR TITLE
Fix config key typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ is given to the bot owner(s) in the Discord Developer Portal (although they will
 - `prefix` is the bot's prefix.
 - `open_message` is the text that users will receive under "Ticket Created" when they open a ticket.
 - `close_message` is the text that users will receive under "Ticket Closed" when a mod closes their ticket.
-- `anonymous_tickets` (true/false) names ticket channels anonymously, rather than using the name of the user.
+- Set `anonymous_tickets` to true to name ticket channels anonymously instead of using the user's name.
 - `send_with_command_only` (true/false) only allows messages to be sent using `!reply` and `!areply`
 
 The `!refresh` command will re-read the config file, so you can change these values without restarting the bot.

--- a/changelogs.txt
+++ b/changelogs.txt
@@ -21,3 +21,5 @@
 * Clarified comments so the translation notice never appears in output.
 * Expanded notice comment to emphasize it is excluded from translations.
 
+* Corrected config key in templates/config.json to `anonymous_tickets` and updated README accordingly.
+

--- a/templates/config.json
+++ b/templates/config.json
@@ -10,5 +10,5 @@
   "prefix": "prefix",
   "open_message": "open_message",
   "close_message": "close_message",
-  "anonomyous_tickets": false
+  "anonymous_tickets": false
 }


### PR DESCRIPTION
## Summary
- fix `templates/config.json` to use `anonymous_tickets`
- clarify `anonymous_tickets` usage in README
- note correction in changelog

## Testing
- `python -m py_compile modmail.py`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6888b650a2b8832f93d808c00a7ce6e0