### PR TITLE
Ensure config loads with UTF-8 encoding

### DIFF
--- a/changelogs.txt
+++ b/changelogs.txt
@@ -35,3 +35,5 @@
 
 * Corrected config key in templates/config.json to `anonymous_tickets` and updated README accordingly.
 
+* Fixed config loading to always use UTF-8 so Japanese text and emoji in modmail responses display correctly.
+

--- a/modmail.py
+++ b/modmail.py
@@ -116,7 +116,7 @@ def normalise_config_keys(data: dict) -> dict:
     return data
 
 
-with open('config.json', 'r') as config_file:
+with open('config.json', 'r', encoding='utf-8') as config_file:
     config = Config(**normalise_config_keys(json.load(config_file)))
 
 
@@ -1901,7 +1901,7 @@ async def ping(ctx):
 async def refresh(ctx):
     """Re-reads the external config file"""
 
-    with open('config.json', 'r') as file:
+    with open('config.json', 'r', encoding='utf-8') as file:
 
         config.update(normalise_config_keys(json.load(file)))
     await ctx.message.add_reaction('\u2705')


### PR DESCRIPTION
## Summary
- ensure config.json is always read with UTF-8 encoding during startup and manual refresh so unicode text remains intact

## Testing
- python -m py_compile modmail.py

------
https://chatgpt.com/codex/tasks/task_e_68daadd43b3c832f8c4a73dd205438fa