### PR TITLE
Create dedicated broadcast forums and add closebroadcast command

### DIFF
--- a/changelogs.txt
+++ b/changelogs.txt
@@ -1,4 +1,6 @@
 
+* Broadcast command now spins up a dedicated forum channel for each announcement and tags broadcast-created tickets for cleanup.
+* Added a `!closebroadcast` command to retire broadcast-only tickets and remove the temporary coordination forum.
 * Ensured newly created ticket threads are fetched before use so the first DM no longer fails with Unknown Channel errors.
 * Reduced the delay on opening DMs by scheduling forum title updates asynchronously and preventing them from blocking ticket creation.
 * Fixed the forum title counter so it no longer appends duplicate numbers when Discord slugifies the channel name.


### PR DESCRIPTION
## Summary
- create dedicated forum channels for each broadcast and track broadcast-created tickets
- add helpers to manage broadcast-created ticket records and a command to close broadcast threads
- update the close command to gracefully handle broadcast forums and expand the changelog

## Testing
- python -m compileall modmail.py

------
https://chatgpt.com/codex/tasks/task_e_68daaed9441c832f8de57c1319faabed