### PR TITLE
Expand group tag workflows and harden error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,21 @@ From v.1.1.0 onwards there is also an option to send messages only with the comm
 
 - `!send` creates a new ticket and sends an anonymous message to a user that does not already have a ticket open.
 
-- `!broadcast` creates a pinned "Send to All" coordination thread that delivers a message to several tickets at once and keeps every linked conversation in sync.
+- `!sendmany`, the various `!replymany` flavours, and the `!closemany` family let you tag a group of tickets with a temporary label, deliver the same update to each one, and close them together when the follow-up is finished.
+
+### Group tag bulk commands
+
+Use the group tag commands when you need to contact several members about the same topic. Every command works with the temporary group tag created by `!sendmany` so you can keep their ticket updates together.
+
+- `!sendmany <ids> <group name> <message>` — Provide a comma-separated list of user IDs and a group name. The command opens tickets as needed, sends the anonymous message (or attachments) to every member, and tags their threads so you can follow up later.
+- `!replymany <group name> <message>` — Sends a normal moderator reply to each ticket currently tagged with the supplied group name. You can include attachments exactly like a regular reply.
+- `!areplymany <group name> <message>` — Delivers the same update anonymously so the acting moderator stays hidden inside every ticket thread.
+- `!replytmany <group name> <language> <message>` and `!areplytmany <group name> <language> <message>` — Translate the shared response before sending it, with the anonymous variant keeping moderator identities concealed.
+- `!closemany <group name> [reason]` — Closes all tickets tagged with the group name and removes the temporary tag afterwards. The optional reason is logged just like the standard `!close` command.
+- `!aclosemany <group name> [reason]` — Closes the tickets while anonymising the moderator in the internal log entry.
+- `!clostmany <group name> <language> [reason]` (alias `!closetmany`) and `!aclosetmany <group name> <language> [reason]` — Close every tagged ticket after translating the reason for users, with the anonymous version keeping moderator details private.
+
+When you finish working with a group, the closing commands automatically delete the temporary forum tag once every ticket has been removed.
 
 - **The following is features I (Codyno) have added onto the existing bot**:
 

--- a/changelogs.txt
+++ b/changelogs.txt
@@ -1,4 +1,14 @@
 
+* Added shared group-reply helper and expanded the command set with `!areplymany`, `!replytmany`, and `!areplytmany` for anonymous and translated follow-ups.
+* Introduced `!aclosemany`, `!clostmany`/`!closetmany`, and `!aclosetmany` so bulk closures can be anonymous or translated while keeping forum tags tidy.
+* Hardened the error handler to skip missing error channels gracefully and ensure the owner always receives stack traces.
+* Forced `config.json` to load with UTF-8 so automated ticket messages preserve emoji and other non-ASCII characters.
+* Delayed temporary tag cleanup until after ticket deletion and report failures so moderators know when manual intervention is required.
+* Documented the `!sendmany`, `!replymany`, and `!closemany` group workflow in the README so moderators know how to use the new commands.
+* Removed the broadcast forum workflow and its commands in favor of simpler group-tag automation.
+* Added `!sendmany`, `!replymany`, and `!closemany` commands for sending, replying, and closing groups of tickets via temporary tags.
+* Persisted group tag membership in the database and clean up tags automatically when tickets close.
+* Refactored ticket closure into a reusable helper so every close path shares the same logging, transcript, and DM flow.
 * Ensured newly created ticket threads are fetched before use so the first DM no longer fails with Unknown Channel errors.
 * Reduced the delay on opening DMs by scheduling forum title updates asynchronously and preventing them from blocking ticket creation.
 * Fixed the forum title counter so it no longer appends duplicate numbers when Discord slugifies the channel name.


### PR DESCRIPTION
## Summary
- add shared helpers for group replies and closes alongside new anonymous and translated variants of the `!replymany` and `!closemany` commands
- ensure temporary tags are removed after bulk closes, require UTF-8 for config loading, and guard the error handler when the error channel is missing
- document the expanded bulk command set in the README and changelog

## Testing
- python -m compileall modmail.py

------
https://chatgpt.com/codex/tasks/task_e_68daaed9441c832f8de57c1319faabed