### PR TITLE
Fix forum tag deletion compatibility

### DIFF
--- a/changelogs.txt
+++ b/changelogs.txt
@@ -1,4 +1,5 @@
 
+* Fixed group tag cleanup to remain compatible with discord.py versions that do not expose `ForumChannel.delete_tag`.
 * Simplified configuration loading to avoid syntax errors seen on Windows deployments when constructing the `Config` object.
 * Added shared group-reply helper and expanded the command set with `!areplymany`, `!replytmany`, and `!areplytmany` for anonymous and translated follow-ups.
 * Introduced `!aclosemany`, `!clostmany`/`!closetmany`, and `!aclosetmany` so bulk closures can be anonymous or translated while keeping forum tags tidy.

--- a/modmail.py
+++ b/modmail.py
@@ -489,7 +489,10 @@ async def delete_group_tag(forum_channel: discord.ForumChannel, tag: discord.For
     """Attempt to remove the provided forum tag and report success."""
 
     try:
-        await forum_channel.delete_tag(tag)
+        remaining_tags = [existing for existing in forum_channel.available_tags if existing.id != tag.id]
+        if len(remaining_tags) == len(forum_channel.available_tags):
+            return False
+        await forum_channel.edit(available_tags=remaining_tags)
         return True
     except discord.HTTPException:
         return False


### PR DESCRIPTION
## Summary
- replace the use of the missing ForumChannel.delete_tag helper with an edit-based fallback
- ensure group tag cleanup succeeds on discord.py versions lacking the helper

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db34029990832f9f0493a5027e6bd8