### PR TITLE
Ensure ticket closure DM sends before transcript generation

### DIFF
--- a/changelogs.txt
+++ b/changelogs.txt
@@ -1,4 +1,5 @@
 
+* Sent ticket closure DMs before transcript generation so users receive the "Ticket Closed" notice without delay.
 * Simplified configuration loading to avoid syntax errors seen on Windows deployments when constructing the `Config` object.
 * Added shared group-reply helper and expanded the command set with `!areplymany`, `!replytmany`, and `!areplytmany` for anonymous and translated follow-ups.
 * Introduced `!aclosemany`, `!clostmany`/`!closetmany`, and `!aclosetmany` so bulk closures can be anonymous or translated while keeping forum tags tidy.

--- a/modmail.py
+++ b/modmail.py
@@ -924,6 +924,12 @@ async def close_ticket_thread(
         icon_url = embed_user.footer.icon_url if embed_user.footer else None
         embed_user.set_footer(text=translation_notice, icon_url=icon_url)
 
+    if user is not None:
+        try:
+            await user.send(embed=embed_user)
+        except discord.Forbidden:
+            pass
+
     summary = None
     try:
         with open(txt_path, 'r', encoding='utf-8') as summary_file:
@@ -971,12 +977,6 @@ async def close_ticket_thread(
         os.remove(htm_path)
     except OSError:
         pass
-
-    if user is not None:
-        try:
-            await user.send(embed=embed_user)
-        except discord.Forbidden:
-            pass
 
     return True, None
 


### PR DESCRIPTION
## Summary
- send the ticket closure direct message before transcript and logging work so users receive the closing notice promptly
- document the behavior change in the changelog

## Testing
- python -m compileall modmail.py

------
https://chatgpt.com/codex/tasks/task_e_68db34c4b610832f959d3984cbaaf78f