### PR TITLE
Fix translated ticket closure reason logging

### DIFF
--- a/changelogs.txt
+++ b/changelogs.txt
@@ -1,3 +1,4 @@
+* Fixed translated ticket closure logs so the reason shows both the translated and original text correctly.
 * Sent ticket closure DMs before transcript generation so users receive the "Ticket Closed" notice without delay.
 * Removed the forum ticket counter so the forum name no longer changes as tickets open or close.
 * Fixed group tag cleanup to remain compatible with discord.py versions that do not expose `ForumChannel.delete_tag`.

--- a/modmail.py
+++ b/modmail.py
@@ -881,11 +881,13 @@ async def close_ticket_thread(
     embed_guild = embed_creator('Ticket Closed', '', 'r', user or guild, moderator, anon=log_anon)
 
     final_user_reason = user_reason if user_reason is not None else reason
+    display_reason = final_user_reason or reason
+
     if final_user_reason:
         embed_user.add_field(name='Reason', value=final_user_reason, inline=False)
-    if reason:
-        embed_guild.add_field(name='Reason', value=reason, inline=False)
-    if original_reason and original_reason != final_user_reason:
+    if display_reason:
+        embed_guild.add_field(name='Reason', value=display_reason, inline=False)
+    if original_reason and original_reason != display_reason:
         embed_user.add_field(name='Original Reason', value=original_reason, inline=False)
         embed_guild.add_field(name='Original Reason', value=original_reason, inline=False)
     if translation_notice:


### PR DESCRIPTION
## Summary
- ensure modmail close logs display the translated reason in addition to the original text
- document the fix in the changelog

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbd1af4380832f8459248b8271b76a