### PR TITLE
Ensure closemany transcripts include closing reasons

### DIFF
--- a/changelogs.txt
+++ b/changelogs.txt
@@ -1,3 +1,5 @@
+* Included closing reasons in ticket threads before transcript generation so bulk close logs capture the context.
+* Reopened archived threads before closing so closemany commands reliably post transcripts to the log channel.
 * Fixed translated ticket closure logs so the reason shows both the translated and original text correctly.
 * Sent ticket closure DMs before transcript generation so users receive the "Ticket Closed" notice without delay.
 * Removed the forum ticket counter so the forum name no longer changes as tickets open or close.

--- a/modmail.py
+++ b/modmail.py
@@ -711,6 +711,10 @@ async def close_ticket_thread(
     if not isinstance(thread, discord.Thread) or thread.parent_id != config.forum_channel_id:
         return False, 'This channel is not a valid ticket.'
 
+    # Bug fix: reopen archived threads so closemany variants can post the closing
+    # notice and generate transcripts just like the single-ticket close command.
+    thread = await ensure_thread_open(thread)
+
     for text in (reason, user_reason, original_reason):
         if text and len(text) > 1024:
             return False, 'Reason too long: the maximum length for closing reasons is 1024 characters.'
@@ -760,7 +764,26 @@ async def close_ticket_thread(
         conn.commit()
     remove_thread_from_groups(thread.id)
 
-    await thread.send(embed=embed_creator('Closing Ticket...', '', 'b'))
+    final_user_reason = user_reason if user_reason is not None else reason
+    display_reason = final_user_reason or reason
+
+    closing_embed = embed_creator(
+        'Closing Ticket...',
+        'Generating the transcript before closing this ticket.',
+        'b'
+    )
+    if final_user_reason:
+        closing_embed.add_field(name='Reason Sent to User', value=final_user_reason, inline=False)
+    if original_reason and original_reason != final_user_reason:
+        closing_embed.add_field(name='Original Reason', value=original_reason, inline=False)
+    elif reason and final_user_reason != reason:
+        closing_embed.add_field(name='Moderator Reason', value=reason, inline=False)
+    elif reason and not final_user_reason:
+        closing_embed.add_field(name='Moderator Reason', value=reason, inline=False)
+    if translation_notice:
+        closing_embed.add_field(name='Translation Notice', value=translation_notice, inline=False)
+
+    await thread.send(embed=closing_embed)
 
     try:
         channel_messages = [message async for message in thread.history(limit=1024, oldest_first=True)]
@@ -879,9 +902,6 @@ async def close_ticket_thread(
     guild = thread.guild or bot.get_guild(config.guild_id)
     embed_user = embed_creator('Ticket Closed', config.close_message, 'b', guild, time=True)
     embed_guild = embed_creator('Ticket Closed', '', 'r', user or guild, moderator, anon=log_anon)
-
-    final_user_reason = user_reason if user_reason is not None else reason
-    display_reason = final_user_reason or reason
 
     if final_user_reason:
         embed_user.add_field(name='Reason', value=final_user_reason, inline=False)


### PR DESCRIPTION
## Summary
- post a closing embed with the translated and original reasons before transcripts are generated so bulk closures log their context
- document the closing transcript update in the changelog

## Testing
- python -m compileall modmail.py

------
https://chatgpt.com/codex/tasks/task_e_68dbdac361e4832f90c7cdd19535df96