### PR TITLE
Use custom activity for bot presence

### DIFF
--- a/changelogs.txt
+++ b/changelogs.txt
@@ -1,3 +1,4 @@
+* Switched the bot status to a custom activity so it shows "DM to Contact Mods" without the "Playing" prefix.
 * Fixed translated ticket closure logs so the reason shows both the translated and original text correctly.
 * Sent ticket closure DMs before transcript generation so users receive the "Ticket Closed" notice without delay.
 * Removed the forum ticket counter so the forum name no longer changes as tickets open or close.

--- a/modmail.py
+++ b/modmail.py
@@ -594,7 +594,7 @@ def buffers_to_payloads(buffers: list[tuple[io.BytesIO, str]]) -> list[tuple[str
 
 
 bot = commands.Bot(command_prefix=config.prefix, intents=discord.Intents.all(),
-                   activity=discord.Game('DM to Contact Mods'), help_command=HelpCommand())
+                   activity=discord.Activity(type=discord.ActivityType.custom, name='DM to Contact Mods'), help_command=HelpCommand())
 
 
 @bot.event


### PR DESCRIPTION
## Summary
- switch the bot presence to a custom activity so it no longer shows the Playing prefix
- document the status update in the changelog

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e249937d30832fa044f2a785ebaebe