### PR TITLE
Fix custom status presence for ModMail bot

### DIFF
--- a/changelogs.txt
+++ b/changelogs.txt
@@ -1,4 +1,4 @@
-* Switched the bot status to a custom activity so it shows "DM to Contact Mods" without the "Playing" prefix.
+* Restored the "DM to Contact Mods" status by switching to discord.CustomActivity so it appears reliably.
 * Fixed translated ticket closure logs so the reason shows both the translated and original text correctly.
 * Sent ticket closure DMs before transcript generation so users receive the "Ticket Closed" notice without delay.
 * Removed the forum ticket counter so the forum name no longer changes as tickets open or close.

--- a/modmail.py
+++ b/modmail.py
@@ -594,7 +594,7 @@ def buffers_to_payloads(buffers: list[tuple[io.BytesIO, str]]) -> list[tuple[str
 
 
 bot = commands.Bot(command_prefix=config.prefix, intents=discord.Intents.all(),
-                   activity=discord.Activity(type=discord.ActivityType.custom, name='DM to Contact Mods'), help_command=HelpCommand())
+                   activity=discord.CustomActivity(name='DM to Contact Mods'), help_command=HelpCommand())
 
 
 @bot.event


### PR DESCRIPTION
## Summary
- set the bot presence to use `discord.CustomActivity` so "DM to Contact Mods" shows up reliably
- record the status fix in the changelog

## Testing
- not run (presence change only)


------
https://chatgpt.com/codex/tasks/task_e_68e6746f53c8832fa1e4ebce8226fa14