### PR TITLE
Fix send membership check when member cache is disabled

### DIFF
--- a/changelogs.txt
+++ b/changelogs.txt
@@ -1,3 +1,4 @@
+* Fixed `!send`, standard replies, and translated replies falsely failing with "User not in server" by replacing `mutual_guilds` checks with cache-aware guild member lookups.
 * Replaced internal Discord view timeouts for help option prompts and the config wizard with manual expiry checks, eliminating `BaseView.__timeout_task_impl` runtime warnings while preserving the same user-facing timeout behavior.
 * Limited translation cache reads/writes to automatic localisation messages so manual translated replies always request a fresh translation.
 * Added an admin-only `/memoryusage` slash command that shows per-task memory delta graphs and a leaderboard of top memory hungry tasks.

--- a/modmail.py
+++ b/modmail.py
@@ -1555,6 +1555,18 @@ async def interaction_is_mod(interaction: discord.Interaction) -> bool:
     return member.top_role >= mod_role
 
 
+async def resolve_guild_member(guild: discord.Guild, user_id: int) -> discord.Member | None:
+    """Return a guild member using cache first, then API fallback when cache is disabled."""
+
+    member = guild.get_member(user_id)
+    if member is not None:
+        return member
+    try:
+        return await guild.fetch_member(user_id)
+    except (discord.NotFound, discord.HTTPException):
+        return None
+
+
 # Feature: validate that configured channels expecting plain-text output are still text channels.
 def require_text_channel(channel_id: int, purpose: str) -> discord.TextChannel:
     """Return the named text channel or raise if it is missing or the wrong type."""
@@ -2910,7 +2922,8 @@ async def send_message(message, text, anon):
         if user is None:
             # Bug fix: assign fetch results so downstream checks and sends always use a resolved user object.
             user = await bot.fetch_user(user_id)
-        elif message.guild not in user.mutual_guilds:
+        # Bug fix: validate membership with guild member lookups because mutual_guilds can be empty when member caching is disabled.
+        elif await resolve_guild_member(message.guild, user_id) is None:
             await message.channel.send(embed=embed_creator('Failed to Send', 'User not in server.', 'e'))
             return
     except (ValueError, TypeError, discord.NotFound):
@@ -3171,7 +3184,8 @@ async def send_translated_message(message, language: str, text: str, anon: bool)
         if user is None:
             # Bug fix: assign fetch results so downstream checks and sends always use a resolved user object.
             user = await bot.fetch_user(user_id)
-        elif message.guild not in user.mutual_guilds:
+        # Bug fix: validate membership with guild member lookups because mutual_guilds can be empty when member caching is disabled.
+        elif await resolve_guild_member(message.guild, user_id) is None:
             await message.channel.send(embed=embed_creator('Failed to Send', 'User not in server.', 'e'))
             return
     except (ValueError, TypeError, discord.NotFound):
@@ -3440,7 +3454,8 @@ async def send(ctx, user: discord.User, *, message: str = ''):
             return
 
 
-    if ctx.guild not in user.mutual_guilds:
+    # Bug fix: validate membership with guild member lookups because mutual_guilds can be empty when member caching is disabled.
+    if await resolve_guild_member(ctx.guild, user.id) is None:
         await ctx.send(embed=embed_creator('Failed to Send', 'User not in server.', 'e'))
         return
 


### PR DESCRIPTION
### Motivation

- Sending messages from moderators to users was sometimes failing with "User not in server." because checks relied on `user.mutual_guilds`, which can be empty when member caching is disabled.
- The goal is to make membership checks reliable under low-memory / cache-less Discord client configurations so moderator replies and `!send` work consistently.

### Description

- Added a shared helper `resolve_guild_member(guild, user_id)` that checks `guild.get_member` first and falls back to `guild.fetch_member` if needed.
- Replaced `user.mutual_guilds` membership checks with `await resolve_guild_member(...) is None` in `send_message`, `send_translated_message`, and the `!send` command.
- Updated `changelogs.txt` to document the fix.

### Testing

- Compiled the module with `python -m py_compile modmail.py`, which succeeded with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a976c862d0832fa58c1dde7dfb8beb)